### PR TITLE
Avoid infinite recursions in terraform parser

### DIFF
--- a/blastradius/handlers/terraform.py
+++ b/blastradius/handlers/terraform.py
@@ -18,7 +18,7 @@ class Terraform:
         self.settings = settings if settings else {}
 
         # handle the root module first...
-        self.directory = directory if directory else os.getcwd()
+        self.directory = os.path.abspath(directory) if directory else os.getcwd()
         #print(self.directory)
         self.config_str = ''
         iterator = iglob( self.directory + '/*.tf')
@@ -66,6 +66,9 @@ class Terraform:
                 # AWS S3 buckets
                 elif re.match(r's3.*\.amazonaws\.com', source):
                     continue
+
+                if source == '.':
+                    continue   # avoid infinite recursion
 
                 path = os.path.join(self.directory, source)
                 if os.path.exists(path):


### PR DESCRIPTION
This patch fixes a case where a sufficiently complicated graph with both local and external modules would generate max recursion depth errors. 

The parser would detect the source as "." and recurse infinitely. This patch fixes the behavior.